### PR TITLE
Change to gh-pages hosting

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+olback.ninja


### PR DESCRIPTION
This PR adds the CNAME file for necessary for hosting on gh-pages with custom domains.

Before you merge this PR you should add a `CNAME` record for olback.ninja that points to `olback.github.io`
Below is a screenshot of my CNAME record for taxi.carlgo11.com:
![screenshot from 2017-01-30 11-34-51](https://cloud.githubusercontent.com/assets/3535780/22419975/3ca44494-e6e0-11e6-87e9-c826799d2ac3.png)

When that's done merge this PR and then go to the [Settings tab](https://github.com/olback/olback.ninja/settings). Under "GitHub Pages" you'll see a setting called "Source". Set that to `master branch`.
![screenshot from 2017-01-30 11-36-42](https://cloud.githubusercontent.com/assets/3535780/22420039/95d05ce2-e6e0-11e6-919a-fbb83665e815.png)

And that's it!
<img src="https://emoji.slack-edge.com/T09K5E2M8/tay/f281b204bc62cd07.png" alt=":tay:" height="32" width="32"/>